### PR TITLE
Use textwrap.fill utility function directly

### DIFF
--- a/rst2rst/writer.py
+++ b/rst2rst/writer.py
@@ -2,7 +2,7 @@
 
 __docformat__ = 'reStructuredText'
 
-from textwrap import TextWrapper
+import textwrap
 
 import docutils
 from docutils import frontend, nodes, utils, writers, languages, io
@@ -169,10 +169,9 @@ class RSTTranslator(nodes.NodeVisitor):
         width = width if width is not None else self.options.wrap_length
         indent = indent if indent is not None else self.indentation
         initial_indent = self.initial_indentation
-        wrapper = TextWrapper(width=width,
-                              initial_indent=initial_indent,
-                              subsequent_indent=indent)
-        return wrapper.fill(text)
+        return textwrap.fill(text, width=width,
+                             initial_indent=initial_indent,
+                             subsequent_indent=indent)
 
     def visit_Text(self, node):
         self.body.append(self.spacer)


### PR DESCRIPTION
Any keyword argument taken by `TextWrapper` can also be passed to the module-level `fill` (or `wrap`) utility functions. Explicitly creating a `TextWrapper` object is unnecessary if the object is immediately discarded and the only customizations are keyword arguments.
